### PR TITLE
Replace deprecated libswiftXCTest.dylib with libXCTestSwiftSupport.dylib

### DIFF
--- a/Nimble.podspec
+++ b/Nimble.podspec
@@ -45,7 +45,7 @@ Pod::Spec.new do |s|
     'DEFINES_MODULE' => 'YES',
     'ENABLE_BITCODE' => 'NO',
     'ENABLE_TESTING_SEARCH_PATHS' => 'YES',
-    'OTHER_LDFLAGS' => '$(inherited) -weak-lswiftXCTest -Xlinker -no_application_extension',
+    'OTHER_LDFLAGS' => '$(inherited) -weak-lXCTestSwiftSupport -Xlinker -no_application_extension',
     'OTHER_SWIFT_FLAGS' => '$(inherited) -suppress-warnings',
   }
 

--- a/Nimble.xcodeproj/project.pbxproj
+++ b/Nimble.xcodeproj/project.pbxproj
@@ -1978,7 +1978,7 @@
 					"$(inherited)",
 					"-weak_framework",
 					XCTest,
-					"-weak-lswiftXCTest",
+					"-weak-lXCTestSwiftSupport",
 				);
 				PRODUCT_BUNDLE_IDENTIFIER = "net.jeffhui.${PRODUCT_NAME:rfc1034identifier}";
 				PRODUCT_MODULE_NAME = Nimble;


### PR DESCRIPTION
Addresses https://github.com/Quick/Nimble/issues/855 to make Nimble work with XCode beta 12.5